### PR TITLE
fix: replace print(e) with logger.exception in Location.save

### DIFF
--- a/people/models.py
+++ b/people/models.py
@@ -15,7 +15,10 @@ from taggit.managers import TaggableManager
 from taggit.models import Tag, TaggedItem
 from tinymce.models import HTMLField
 import os
+import logging
 import settings
+
+logger = logging.getLogger(__name__)
 
 class Country(models.Model):
     name = models.CharField(max_length=50)
@@ -56,7 +59,7 @@ class Location(models.Model):
             except Exception as e:
                 # If something goes wrong, there's not much we can do, just leave
                 # the coordinates blank.
-                print (e)
+                logger.exception("Geocoding failed for %s: %s", query, e)
         super(Location, self).save(*args, **kwargs)
 
     def get_absolute_url(self):


### PR DESCRIPTION
Found a bug while browsing `people/models.py`.

The `Location.save()` method catches every exception from the OpenCage geocoding call and silently swallows it with a plain `print (e)`. This:

1. Dumps the error to stdout, which is dropped in production and unreachable from `docker logs` / process supervisors.
2. Loses the full traceback — only the exception's stringified form is preserved.
3. Skips the project's configured Django logging handler, so sysadmins and Sentry-style integrations never see it.
4. Uses the dangling-space `print (e)` style instead of a clean function call.

### Fix
- Added `import logging` and a module-level `logger = logging.getLogger(__name__)`.
- Swapped `print (e)` for `logger.exception("Geocoding failed for %s: %s", query, e)`, which preserves the traceback and routes to Django's logging config.

### Before / After
```python
# before
except Exception as e:
    # If something goes wrong, there's not much we can do, just leave
    # the coordinates blank.
    print (e)
```

```python
# after
except Exception as e:
    # If something goes wrong, there's not much we can do, just leave
    # the coordinates blank.
    logger.exception("Geocoding failed for %s: %s", query, e)
```

— Sent via @AmSach bot
